### PR TITLE
Fix compiler warning

### DIFF
--- a/src/value.sol
+++ b/src/value.sol
@@ -20,8 +20,8 @@ contract DSValue is DSThing {
         return (val,has);
     }
     function read() constant returns (bytes32) {
-        var (wut, has) = peek();
-        assert(has);
+        var (wut, haz) = peek();
+        assert(haz);
         return wut;
     }
     function poke(bytes32 wut) note auth {


### PR DESCRIPTION
```
src/value.sol:23:19: Warning: This declaration shadows an existing declaration.
        var (wut, has) = peek();
                  ^-^
src/value.sol:17:5: The shadowed declaration is here:
    bool    has;
    ^---------^
```