### PR TITLE
Change assert to require

### DIFF
--- a/src/value.sol
+++ b/src/value.sol
@@ -28,7 +28,7 @@ contract DSValue is DSThing {
     function read() public view returns (bytes32) {
         bytes32 wut; bool haz;
         (wut, haz) = peek();
-        assert(haz);
+        require(haz, "haz-not");
         return wut;
     }
     function poke(bytes32 wut) public note auth {


### PR DESCRIPTION
No need to use up all the gas if `read` is called before `poke`.